### PR TITLE
Fixed uriInfo to work with keycloak standalone for jboss

### DIFF
--- a/src/main/java/com.instipod.duouniversal/DuoUniversalAuthenticator.java
+++ b/src/main/java/com.instipod.duouniversal/DuoUniversalAuthenticator.java
@@ -137,7 +137,7 @@ public class DuoUniversalAuthenticator implements org.keycloak.authentication.Au
             String loginState = authenticationFlowContext.getAuthenticationSession().getAuthNote("DUO_STATE");
             String loginUsername = authenticationFlowContext.getAuthenticationSession().getAuthNote("DUO_USERNAME");
 
-            MultivaluedMap<String, String> queryParams = authenticationFlowContext.getHttpRequest().getUri().getQueryParameters();
+            MultivaluedMap<String, String> queryParams = authenticationFlowContext.getUriInfo().getQueryParameters();
             if (queryParams.containsKey("state") && queryParams.containsKey("duo_code")) {
                 String state = queryParams.getFirst("state");
                 String duoCode = queryParams.getFirst("duo_code");


### PR DESCRIPTION
This class would error out after return from Duo prompt with a java error missing method getUriInfo in jboss resteasy.

Deployed / tested in keycloak 16.1.0

Deceptively simple fix for amount of time spent troubleshooting.