### PR TITLE
Ensure groups logic works with Keycloak 20+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <keycloak.version>18.0.0</keycloak.version>
+        <keycloak.version>21.0.1</keycloak.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/instipod/duouniversal/DuoUniversalAuthenticator.java
+++ b/src/main/java/com/instipod/duouniversal/DuoUniversalAuthenticator.java
@@ -148,7 +148,7 @@ public class DuoUniversalAuthenticator implements Authenticator {
         }
         String username = user.getUsername();
         if (!duoRequired(duoGroups, user)) {
-            String userGroupsStr = user.getGroups().stream().map(GroupModel::getName).collect(Collectors.joining(","));
+            String userGroupsStr = user.getGroupsStream().map(GroupModel::getName).collect(Collectors.joining(","));
             logger.infof("Skipping Duo MFA for %s based on group membership, groups=%s", username, userGroupsStr);
             authenticationFlowContext.success();
             return;
@@ -258,8 +258,9 @@ public class DuoUniversalAuthenticator implements Authenticator {
         if (duoGroups == "none") return true;
         if (duoGroups != null && duoGroups.isEmpty()) return true;
         List<String> groups = Arrays.asList(duoGroups.split(","));
-        for (GroupModel group : user.getGroups()) {
-            if (groups.contains(group.getName())) {
+        List<String> groupNames = user.getGroupsStream().map(GroupModel::getName).collect(Collectors.toList());
+        for (String group : groupNames) {
+            if (groups.contains(group)) {
                 return true;
             }
         }


### PR DESCRIPTION
The 'getGroups()' method was removed in Keycloak 20 and replaced with 'getGroupsStream()'