### PR TITLE
Fix duo-universal-sdk transitive vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.duosecurity</groupId>
             <artifactId>duo-universal-sdk</artifactId>
             <version>1.1.3</version>


### PR DESCRIPTION
The Duo lib `duo-universal-sdk` contains a transitive vulnerability inherited from the library `OkHttp:3.14.9`.

The vulnerability is [CVE-2023-3635](https://www.cve.org/CVERecord?id=CVE-2023-3635).

Adding a more recent version of `OkHttp` to `pom.xml` (before the Duo library) prevents loading the vulnerable one.